### PR TITLE
Add mask after declaring a variable

### DIFF
--- a/get-kv-secret/action.yml
+++ b/get-kv-secret/action.yml
@@ -21,6 +21,6 @@ runs:
     env:
       KV_SECRET: "MASK ME"
     run: |
-      echo "::add-mask::$KV_SECRET"
       KV_SECRET=$(az keyvault secret show --name ${{ inputs.secret_name }} --vault-name ${{ inputs.keyvault_name }} --query "value")
+      echo "::add-mask::$KV_SECRET"
       echo "::set-output name=secret::$(echo $KV_SECRET)"

--- a/get-token/action.yaml
+++ b/get-token/action.yaml
@@ -17,6 +17,6 @@ runs:
     env:
       TOKEN: "MASK ME"
     run: |
-      echo "::add-mask::$TOKEN"
       TOKEN=$(az account get-access-token --resource ${{ inputs.resource_uri }} --query accessToken)
+      echo "::add-mask::$TOKEN"
       echo "::set-output name=token::$(echo $TOKEN)"


### PR DESCRIPTION
Switched the lines to capture the credentials as a variable first and then provide it to add-mask. The other way round leaks the credentials when this action is used.